### PR TITLE
Pipeline resource migration

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,13 @@
+version: 0.2
+phases:
+  install:
+    runtime-versions:
+      nodejs: 12
+    commands:
+      - npm i react-scripts
+  build:
+    commands:
+      - set -eu
+      - env | grep REACT
+      - npm run build
+      - npm run deploy

--- a/deploy/app.py
+++ b/deploy/app.py
@@ -29,9 +29,9 @@ props = {
         "dev": "data-portal-status-page-client-dev",
         "prod": "data-portal-status-page-client-prod"
     },
-    "repository_source": "data-portal-status-page",
+    "repository_source": "umccr/data-portal-status-page",
     "branch_source": {
-        "dev": "dev",
+        "dev": "pipeline-resource-migration",
         "prod": "main"
     }
 }

--- a/deploy/app.py
+++ b/deploy/app.py
@@ -31,7 +31,7 @@ props = {
     },
     "repository_source": "umccr/data-portal-status-page",
     "branch_source": {
-        "dev": "pipeline-resource-migration",
+        "dev": "dev",
         "prod": "main"
     }
 }

--- a/deploy/pipelines/cdkpipeline.py
+++ b/deploy/pipelines/cdkpipeline.py
@@ -59,21 +59,6 @@ class CdkPipelineStack(cdk.Stack):
             block_public_access= s3.BlockPublicAccess.BLOCK_ALL
         )
 
-        source_artifact = codepipeline.Artifact(
-            artifact_name="data_portal_status_page_source_artifact",
-        )
-
-        # Fetch github repository for changes
-        code_star_action = codepipeline_actions.CodeStarConnectionsSourceAction(
-            connection_arn=codestar_arn,
-            output=source_artifact,
-            owner="umccr",
-            repo=props["repository_source"],
-            branch=props["branch_source"][app_stage],
-            action_name="Source",
-            trigger_on_push=True
-        )
-
         # Create a pipeline for status page
         status_page_pipeline = codepipeline.Pipeline(
             self,
@@ -82,14 +67,23 @@ class CdkPipelineStack(cdk.Stack):
             restart_execution_on_update=True,
             cross_account_keys=False,
             pipeline_name=props["pipeline_name"][app_stage],
-
         )
 
-        # Source Stage
-        status_page_pipeline.add_stage(
-            stage_name="StatusPageGitHubSource",
-            actions=[code_star_action]
+        # Create codestar connection fileset
+        code_pipeline_source = pipelines.CodePipelineSource.connection(
+            repo_string=props["repository_source"],
+            branch=props["branch_source"][app_stage],
+            connection_arn=codestar_arn,
+            trigger_on_push=True
         )
+
+
+        # Grab code_pipeline_source artifact
+        ArtifactMap = pipelines.ArtifactMap()
+        source_artifact = ArtifactMap.to_code_pipeline(
+            x=code_pipeline_source.primary_output
+        )
+
 
         # Create A pipeline for cdk stack and react build
         self_mutate_pipeline = pipelines.CodePipeline(
@@ -98,6 +92,7 @@ class CdkPipelineStack(cdk.Stack):
             code_pipeline=status_page_pipeline,
             synth=pipelines.ShellStep(
                 "CDKShellScript",
+                input=code_pipeline_source,
                 commands=[
                     "cdk synth",
                     "mkdir ./cfnnag_output",
@@ -114,98 +109,110 @@ class CdkPipelineStack(cdk.Stack):
             )
         )
 
-        front_end_bucket_arn = s3.Bucket.from_bucket_name(
-            self,
-            "FrontEndBucket",
-            bucket_name=props["bucket_name"][app_stage]
-        ).bucket_arn
-
         # Deploy infrastructure
-        status_page_pipeline.add_stage(
+        self_mutate_pipeline.add_stage(
             DataPortalStatusPageStage(
                 self,
                 "DataPortalStatusPageStage",
             )
         )
 
+        front_end_bucket_arn = s3.Bucket.from_bucket_name(
+            self,
+            "FrontEndBucket",
+            bucket_name=props["bucket_name"][app_stage]
+        ).bucket_arn
 
+        self_mutate_pipeline.build_pipeline()
 
-        # TODO: Create CodeBuild to build React Code
-        # Below Implementation using CDK Pipeline API to is deprecated
-        # https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_pipelines.CdkPipeline.html
+        # Create CodeBuild Project 
+        react_codebuild_project = codebuild.PipelineProject(
+            self,
+            "ProjectReactBuild",
+            check_secrets_in_plain_text_env_variables=False,
+            description="The project from codebuild to build react project.",
+            project_name="DataPortalStatusPageReactBuild"
+        )
 
-        # # Create React Build app stage
-        # react_build_stage = status_page_pipeline.pipeline.add_stage(
-        #     stage_name="ReactBuild",
-        #     actions=[pipelines.ShellScriptAction(
-        #         action_name="BuildScript",
-        #         environment_variables={
-        #             "REACT_APP_REGION": codebuild.BuildEnvironmentVariable(
-        #                 value="ap-southeast-2",
-        #                 type=codebuild.BuildEnvironmentVariableType.PLAINTEXT
-        #             ),
-        #             "REACT_APP_BUCKET_NAME": codebuild.BuildEnvironmentVariable(
-        #                 value=props["bucket_name"][app_stage],
-        #                 type=codebuild.BuildEnvironmentVariableType.PLAINTEXT
-        #             ),
-        #             "REACT_APP_DATA_PORTAL_API_DOMAIN": codebuild.BuildEnvironmentVariable(
-        #                 value="/data_portal/backend/api_domain_name",
-        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-        #             ),
-        #             "REACT_APP_COG_USER_POOL_ID": codebuild.BuildEnvironmentVariable(
-        #                 value="/data_portal/client/cog_user_pool_id",
-        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-        #             ),
-        #             "REACT_APP_COG_APP_CLIENT_ID": codebuild.BuildEnvironmentVariable(
-        #                 value="/data_portal/status_page/cog_app_client_id_stage",
-        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-        #             ),
-        #             "REACT_APP_OAUTH_DOMAIN": codebuild.BuildEnvironmentVariable(
-        #                 value="/data_portal/client/oauth_domain",
-        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-        #             ),
-        #             "REACT_APP_OAUTH_REDIRECT_IN": codebuild.BuildEnvironmentVariable(
-        #                 value="/data_portal/status_page/oauth_redirect_in_stage",
-        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-        #             ),
-        #             "REACT_APP_OAUTH_REDIRECT_OUT": codebuild.BuildEnvironmentVariable(
-        #                 value="/data_portal/status_page/oauth_redirect_out_stage",
-        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-        #             ),
-        #         },
-        #         commands=[
-        #             "env | grep REACT",
-        #             "npm i react-scripts",
-        #             "npm run build",
-        #             "npm run deploy"
-        #         ],
-        #         role_policy_statements=[
-        #             iam.PolicyStatement(
-        #                 actions=["ssm:GetParameter"],
-        #                 effect=iam.Effect.ALLOW,
-        #                 resources=[
-        #                     "arn:aws:ssm:%s:%s:parameter/data_portal/status_page/*" % (
-        #                         self.region, self.account),
-        #                     "arn:aws:ssm:%s:%s:parameter/data_portal/client/*" % (
-        #                         self.region, self.account)
-        #                 ]
-        #             ),
-        #             iam.PolicyStatement(
-        #                 actions=[
-        #                     "s3:DeleteObject",
-        #                     "s3:GetObject",
-        #                     "s3:ListBucket",
-        #                     "s3:PutObject"
-        #                 ],
-        #                 effect=iam.Effect.ALLOW,
-        #                 resources=[
-        #                     front_end_bucket_arn,
-        #                     front_end_bucket_arn + "/*"
-        #                 ]
-        #             )
-        #         ]
-        #     )]
-        # )
+        react_codebuild_project.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["ssm:GetParameter"],
+                effect=iam.Effect.ALLOW,
+                resources=[
+                    "arn:aws:ssm:%s:%s:parameter/data_portal/status_page/*" % (
+                        self.region, self.account),
+                    "arn:aws:ssm:%s:%s:parameter/data_portal/client/*" % (
+                        self.region, self.account)
+                ]
+            )
+        )
+
+        react_codebuild_project.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "s3:DeleteObject",
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:PutObject"
+                ],
+                effect=iam.Effect.ALLOW,
+                resources=[
+                    front_end_bucket_arn,
+                    front_end_bucket_arn + "/*"
+                ]
+            )
+        )
+
+        # CodeBuild for react build script
+        react_build_actions = codepipeline_actions.CodeBuildAction(
+            input=source_artifact,
+            project=react_codebuild_project,
+            check_secrets_in_plain_text_env_variables=False,
+            environment_variables={
+                "REACT_APP_REGION": codebuild.BuildEnvironmentVariable(
+                    value="ap-southeast-2",
+                    type=codebuild.BuildEnvironmentVariableType.PLAINTEXT
+                ),
+                "REACT_APP_BUCKET_NAME": codebuild.BuildEnvironmentVariable(
+                    value=props["bucket_name"][app_stage],
+                    type=codebuild.BuildEnvironmentVariableType.PLAINTEXT
+                ),
+                "REACT_APP_DATA_PORTAL_API_DOMAIN": codebuild.BuildEnvironmentVariable(
+                    value="/data_portal/backend/api_domain_name",
+                    type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+                ),
+                "REACT_APP_COG_USER_POOL_ID": codebuild.BuildEnvironmentVariable(
+                    value="/data_portal/client/cog_user_pool_id",
+                    type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+                ),
+                "REACT_APP_COG_APP_CLIENT_ID": codebuild.BuildEnvironmentVariable(
+                    value="/data_portal/status_page/cog_app_client_id_stage",
+                    type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+                ),
+                "REACT_APP_OAUTH_DOMAIN": codebuild.BuildEnvironmentVariable(
+                    value="/data_portal/client/oauth_domain",
+                    type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+                ),
+                "REACT_APP_OAUTH_REDIRECT_IN": codebuild.BuildEnvironmentVariable(
+                    value="/data_portal/status_page/oauth_redirect_in_stage",
+                    type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+                ),
+                "REACT_APP_OAUTH_REDIRECT_OUT": codebuild.BuildEnvironmentVariable(
+                    value="/data_portal/status_page/oauth_redirect_out_stage",
+                    type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+                ),
+            },
+            type=codepipeline_actions.CodeBuildActionType.BUILD,
+            action_name="ReactBuildAction"
+        )
+
+        # Create React Build app stage
+        react_build_stage = self_mutate_pipeline.pipeline.add_stage(
+            stage_name="ReactBuild",
+            actions=[
+                react_build_actions
+            ]
+        )
 
 
         # react_build_stage.add_actions(

--- a/deploy/pipelines/cdkpipeline.py
+++ b/deploy/pipelines/cdkpipeline.py
@@ -49,12 +49,18 @@ class CdkPipelineStack(cdk.Stack):
                                                                             parameter_name="codestar_github_arn"
                                                                             ).string_value
 
-        cloud_artifact = codepipeline.Artifact(
-            artifact_name="data_portal_status_page_pipeline_cloud"
+        # Create S3 bucket for artifacts
+        pipeline_artifact_bucket = s3.Bucket(
+            self, 
+            "data-portal-status-page-client-bucket", 
+            bucket_name = "data-portal-status-page-artifact-dev",
+            auto_delete_objects = True,
+            removal_policy = cdk.RemovalPolicy.DESTROY,
+            block_public_access= s3.BlockPublicAccess.BLOCK_ALL
         )
 
         source_artifact = codepipeline.Artifact(
-            artifact_name="data_portal_status_page_pipeline_source",
+            artifact_name="data_portal_status_page_source_artifact",
         )
 
         # Fetch github repository for changes
@@ -64,49 +70,48 @@ class CdkPipelineStack(cdk.Stack):
             owner="umccr",
             repo=props["repository_source"],
             branch=props["branch_source"][app_stage],
-            action_name="Source"
+            action_name="Source",
+            trigger_on_push=True
         )
 
-        # Create CDK pipeline
-        pipeline = pipelines.CdkPipeline(
+        # Create a pipeline for status page
+        status_page_pipeline = codepipeline.Pipeline(
             self,
-            "CDKPipeline",
-            cloud_assembly_artifact=cloud_artifact,
-            pipeline_name=props["pipeline_name"][app_stage],
-            source_action=code_star_action,
+            "StatusPageCodePipeline",
+            artifact_bucket=pipeline_artifact_bucket,
+            restart_execution_on_update=True,
             cross_account_keys=False,
-            synth_action=pipelines.SimpleSynthAction(
-                synth_command="cdk synth",
-                cloud_assembly_artifact=cloud_artifact,
-                source_artifact=source_artifact,
-                install_commands=[
-                    "npm install -g aws-cdk",
-                    "gem install cfn-nag",
-                    "pip install -r requirements.txt"
-                ],
-                test_commands=[
+            pipeline_name=props["pipeline_name"][app_stage],
+
+        )
+
+        # Source Stage
+        status_page_pipeline.add_stage(
+            stage_name="StatusPageGitHubSource",
+            actions=[code_star_action]
+        )
+
+        # Create A pipeline for cdk stack and react build
+        self_mutate_pipeline = pipelines.CodePipeline(
+            self,
+            "CodePipeline",
+            code_pipeline=status_page_pipeline,
+            synth=pipelines.ShellStep(
+                "CDKShellScript",
+                commands=[
                     "cdk synth",
                     "mkdir ./cfnnag_output",
                     "for template in $(find ./cdk.out -type f -maxdepth 2 -name '*.template.json'); do cp $template ./cfnnag_output; done",
                     "cfn_nag_scan --input-path ./cfnnag_output"
                 ],
-                action_name="Synth",
-                project_name="data-portal-status-page-synth",
-                subdirectory="deploy"
+                install_commands=[
+                    "cd deploy",
+                    "npm install -g aws-cdk",
+                    "gem install cfn-nag",
+                    "pip install -r requirements.txt"
+                ],
+                primary_output_directory="deploy/cdk.out"
             )
-
-        )
-
-        # Deploy infrastructure
-        pipeline.add_application_stage(
-            DataPortalStatusPageStage(
-                self,
-                "DataPortalStatusPageStage",
-            )
-        )
-
-        react_build_stage = pipeline.add_stage(
-            stage_name="ReactBuild",
         )
 
         front_end_bucket_arn = s3.Bucket.from_bucket_name(
@@ -115,101 +120,189 @@ class CdkPipelineStack(cdk.Stack):
             bucket_name=props["bucket_name"][app_stage]
         ).bucket_arn
 
-        react_build_stage.add_actions(
-            pipelines.ShellScriptAction(
-                action_name="BuildScript",
-                environment_variables={
-                    "REACT_APP_REGION": codebuild.BuildEnvironmentVariable(
-                        value="ap-southeast-2",
-                        type=codebuild.BuildEnvironmentVariableType.PLAINTEXT
-                    ),
-                    "REACT_APP_BUCKET_NAME": codebuild.BuildEnvironmentVariable(
-                        value=props["bucket_name"][app_stage],
-                        type=codebuild.BuildEnvironmentVariableType.PLAINTEXT
-                    ),
-                    "REACT_APP_DATA_PORTAL_API_DOMAIN": codebuild.BuildEnvironmentVariable(
-                        value="/data_portal/backend/api_domain_name",
-                        type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-                    ),
-                    "REACT_APP_COG_USER_POOL_ID": codebuild.BuildEnvironmentVariable(
-                        value="/data_portal/client/cog_user_pool_id",
-                        type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-                    ),
-                    "REACT_APP_COG_APP_CLIENT_ID": codebuild.BuildEnvironmentVariable(
-                        value="/data_portal/status_page/cog_app_client_id_stage",
-                        type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-                    ),
-                    "REACT_APP_OAUTH_DOMAIN": codebuild.BuildEnvironmentVariable(
-                        value="/data_portal/client/oauth_domain",
-                        type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-                    ),
-                    "REACT_APP_OAUTH_REDIRECT_IN": codebuild.BuildEnvironmentVariable(
-                        value="/data_portal/status_page/oauth_redirect_in_stage",
-                        type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-                    ),
-                    "REACT_APP_OAUTH_REDIRECT_OUT": codebuild.BuildEnvironmentVariable(
-                        value="/data_portal/status_page/oauth_redirect_out_stage",
-                        type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
-                    ),
-                },
-                commands=[
-                    "env | grep REACT",
-                    "npm i react-scripts",
-                    "npm run build",
-                    "npm run deploy"
-                ],
-                additional_artifacts=[source_artifact],
-                role_policy_statements=[
-                    iam.PolicyStatement(
-                        actions=["ssm:GetParameter"],
-                        effect=iam.Effect.ALLOW,
-                        resources=[
-                            "arn:aws:ssm:%s:%s:parameter/data_portal/status_page/*" % (
-                                self.region, self.account),
-                            "arn:aws:ssm:%s:%s:parameter/data_portal/client/*" % (
-                                self.region, self.account)
-                        ]
-                    ),
-                    iam.PolicyStatement(
-                        actions=[
-                            "s3:DeleteObject",
-                            "s3:GetObject",
-                            "s3:ListBucket",
-                            "s3:PutObject"
-                        ],
-                        effect=iam.Effect.ALLOW,
-                        resources=[
-                            front_end_bucket_arn,
-                            front_end_bucket_arn + "/*"
-                        ]
-                    )
-                ]
+        # Deploy infrastructure
+        status_page_pipeline.add_stage(
+            DataPortalStatusPageStage(
+                self,
+                "DataPortalStatusPageStage",
             )
         )
 
-        # SSM parameter for AWS SNS ARN
-        data_portal_notification_sns_arn = ssm.StringParameter.from_string_parameter_attributes(
-            self,
-            "DataPortalSNSArn",
-            parameter_name="/data_portal/backend/notification_sns_topic_arn"
-        ).string_value
 
-        # SNS chatbot
-        data_portal_sns_notification = sns.Topic.from_topic_arn(
-            self,
-            "DataPortalSNS",
-            topic_arn=data_portal_notification_sns_arn
-        )
 
-        # Add Chatbot Notificaiton
-        pipeline.code_pipeline.notify_on(
-            "SlackNotificationStatusPage",
-            target=data_portal_sns_notification,
-            events=[
-                codepipeline.PipelineNotificationEvents.PIPELINE_EXECUTION_FAILED,
-                codepipeline.PipelineNotificationEvents.PIPELINE_EXECUTION_SUCCEEDED
-            ],
-            detail_type=codestarnotifications.DetailType.BASIC,
-            enabled=True,
-            notification_rule_name="SlackNotificationStatusPagePipeline"
-        )
+        # TODO: Create CodeBuild to build React Code
+        # Below Implementation using CDK Pipeline API to is deprecated
+        # https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_pipelines.CdkPipeline.html
+
+        # # Create React Build app stage
+        # react_build_stage = status_page_pipeline.pipeline.add_stage(
+        #     stage_name="ReactBuild",
+        #     actions=[pipelines.ShellScriptAction(
+        #         action_name="BuildScript",
+        #         environment_variables={
+        #             "REACT_APP_REGION": codebuild.BuildEnvironmentVariable(
+        #                 value="ap-southeast-2",
+        #                 type=codebuild.BuildEnvironmentVariableType.PLAINTEXT
+        #             ),
+        #             "REACT_APP_BUCKET_NAME": codebuild.BuildEnvironmentVariable(
+        #                 value=props["bucket_name"][app_stage],
+        #                 type=codebuild.BuildEnvironmentVariableType.PLAINTEXT
+        #             ),
+        #             "REACT_APP_DATA_PORTAL_API_DOMAIN": codebuild.BuildEnvironmentVariable(
+        #                 value="/data_portal/backend/api_domain_name",
+        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+        #             ),
+        #             "REACT_APP_COG_USER_POOL_ID": codebuild.BuildEnvironmentVariable(
+        #                 value="/data_portal/client/cog_user_pool_id",
+        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+        #             ),
+        #             "REACT_APP_COG_APP_CLIENT_ID": codebuild.BuildEnvironmentVariable(
+        #                 value="/data_portal/status_page/cog_app_client_id_stage",
+        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+        #             ),
+        #             "REACT_APP_OAUTH_DOMAIN": codebuild.BuildEnvironmentVariable(
+        #                 value="/data_portal/client/oauth_domain",
+        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+        #             ),
+        #             "REACT_APP_OAUTH_REDIRECT_IN": codebuild.BuildEnvironmentVariable(
+        #                 value="/data_portal/status_page/oauth_redirect_in_stage",
+        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+        #             ),
+        #             "REACT_APP_OAUTH_REDIRECT_OUT": codebuild.BuildEnvironmentVariable(
+        #                 value="/data_portal/status_page/oauth_redirect_out_stage",
+        #                 type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+        #             ),
+        #         },
+        #         commands=[
+        #             "env | grep REACT",
+        #             "npm i react-scripts",
+        #             "npm run build",
+        #             "npm run deploy"
+        #         ],
+        #         role_policy_statements=[
+        #             iam.PolicyStatement(
+        #                 actions=["ssm:GetParameter"],
+        #                 effect=iam.Effect.ALLOW,
+        #                 resources=[
+        #                     "arn:aws:ssm:%s:%s:parameter/data_portal/status_page/*" % (
+        #                         self.region, self.account),
+        #                     "arn:aws:ssm:%s:%s:parameter/data_portal/client/*" % (
+        #                         self.region, self.account)
+        #                 ]
+        #             ),
+        #             iam.PolicyStatement(
+        #                 actions=[
+        #                     "s3:DeleteObject",
+        #                     "s3:GetObject",
+        #                     "s3:ListBucket",
+        #                     "s3:PutObject"
+        #                 ],
+        #                 effect=iam.Effect.ALLOW,
+        #                 resources=[
+        #                     front_end_bucket_arn,
+        #                     front_end_bucket_arn + "/*"
+        #                 ]
+        #             )
+        #         ]
+        #     )]
+        # )
+
+
+        # react_build_stage.add_actions(
+            # pipelines.ShellScriptAction(
+            #     action_name="BuildScript",
+            #     environment_variables={
+            #         "REACT_APP_REGION": codebuild.BuildEnvironmentVariable(
+            #             value="ap-southeast-2",
+            #             type=codebuild.BuildEnvironmentVariableType.PLAINTEXT
+            #         ),
+            #         "REACT_APP_BUCKET_NAME": codebuild.BuildEnvironmentVariable(
+            #             value=props["bucket_name"][app_stage],
+            #             type=codebuild.BuildEnvironmentVariableType.PLAINTEXT
+            #         ),
+            #         "REACT_APP_DATA_PORTAL_API_DOMAIN": codebuild.BuildEnvironmentVariable(
+            #             value="/data_portal/backend/api_domain_name",
+            #             type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+            #         ),
+            #         "REACT_APP_COG_USER_POOL_ID": codebuild.BuildEnvironmentVariable(
+            #             value="/data_portal/client/cog_user_pool_id",
+            #             type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+            #         ),
+            #         "REACT_APP_COG_APP_CLIENT_ID": codebuild.BuildEnvironmentVariable(
+            #             value="/data_portal/status_page/cog_app_client_id_stage",
+            #             type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+            #         ),
+            #         "REACT_APP_OAUTH_DOMAIN": codebuild.BuildEnvironmentVariable(
+            #             value="/data_portal/client/oauth_domain",
+            #             type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+            #         ),
+            #         "REACT_APP_OAUTH_REDIRECT_IN": codebuild.BuildEnvironmentVariable(
+            #             value="/data_portal/status_page/oauth_redirect_in_stage",
+            #             type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+            #         ),
+            #         "REACT_APP_OAUTH_REDIRECT_OUT": codebuild.BuildEnvironmentVariable(
+            #             value="/data_portal/status_page/oauth_redirect_out_stage",
+            #             type=codebuild.BuildEnvironmentVariableType.PARAMETER_STORE
+            #         ),
+            #     },
+            #     commands=[
+            #         "env | grep REACT",
+            #         "npm i react-scripts",
+            #         "npm run build",
+            #         "npm run deploy"
+            #     ],
+            #     additional_artifacts=[source_artifact],
+            #     role_policy_statements=[
+            #         iam.PolicyStatement(
+            #             actions=["ssm:GetParameter"],
+            #             effect=iam.Effect.ALLOW,
+            #             resources=[
+            #                 "arn:aws:ssm:%s:%s:parameter/data_portal/status_page/*" % (
+            #                     self.region, self.account),
+            #                 "arn:aws:ssm:%s:%s:parameter/data_portal/client/*" % (
+            #                     self.region, self.account)
+            #             ]
+            #         ),
+            #         iam.PolicyStatement(
+            #             actions=[
+            #                 "s3:DeleteObject",
+            #                 "s3:GetObject",
+            #                 "s3:ListBucket",
+            #                 "s3:PutObject"
+            #             ],
+            #             effect=iam.Effect.ALLOW,
+            #             resources=[
+            #                 front_end_bucket_arn,
+            #                 front_end_bucket_arn + "/*"
+            #             ]
+            #         )
+            #     ]
+            # )
+        # )
+
+        # # SSM parameter for AWS SNS ARN
+        # data_portal_notification_sns_arn = ssm.StringParameter.from_string_parameter_attributes(
+        #     self,
+        #     "DataPortalSNSArn",
+        #     parameter_name="/data_portal/backend/notification_sns_topic_arn"
+        # ).string_value
+
+        # # SNS chatbot
+        # data_portal_sns_notification = sns.Topic.from_topic_arn(
+        #     self,
+        #     "DataPortalSNS",
+        #     topic_arn=data_portal_notification_sns_arn
+        # )
+
+        # # Add Chatbot Notificaiton
+        # pipeline.code_pipeline.notify_on(
+        #     "SlackNotificationStatusPage",
+        #     target=data_portal_sns_notification,
+        #     events=[
+        #         codepipeline.PipelineNotificationEvents.PIPELINE_EXECUTION_FAILED,
+        #         codepipeline.PipelineNotificationEvents.PIPELINE_EXECUTION_SUCCEEDED
+        #     ],
+        #     detail_type=codestarnotifications.DetailType.BASIC,
+        #     enabled=True,
+        #     notification_rule_name="SlackNotificationStatusPagePipeline"
+        # )


### PR DESCRIPTION
Change pipeline API Implementation
- Not using deprecated API (Fix #4 )
- Defined own S3 bucket for pipeline artifact
- Implement code build project instead of auto-generated
- Implement code build action instead of auto-generated
- Use buildspec.yml for build instead of predefined on pipeline