### PR TITLE
Change Workflow Query

### DIFF
--- a/src/components/status/StatusPairing.js
+++ b/src/components/status/StatusPairing.js
@@ -16,7 +16,25 @@ import {
 import { useDialogContext } from "../utils/DialogComponent";
 import StatusTable from "./StatusTable";
 
-function createMetadataObjectFromTNPairing(TNPairingResponse) {
+async function getWorkflowIdFromLibraryId(library_id){
+
+  const APIConfig = {
+    queryStringParameters: {
+      library_id: library_id,
+    },
+  };
+
+  const library_run_response = await API.get(
+    "DataPortalApi",
+    "/libraryrun/",
+    APIConfig
+  );
+  
+  const library_run = library_run_response.results[0]
+  return library_run.workflows
+}
+
+async function createMetadataObjectFromTNPairing(TNPairingResponse) {
   const objectArray = [];
 
   const subject_id = TNPairingResponse.subject_id;
@@ -27,6 +45,7 @@ function createMetadataObjectFromTNPairing(TNPairingResponse) {
       subject_id: subject_id,
       library_id: eachSubject.rglb,
       sample_id: eachSubject.rgsm,
+      workflow_id: await getWorkflowIdFromLibraryId(eachSubject.rglb)
     });
   }
 
@@ -35,6 +54,7 @@ function createMetadataObjectFromTNPairing(TNPairingResponse) {
       subject_id: subject_id,
       library_id: eachSubject.rglb,
       sample_id: eachSubject.rgsm,
+      workflow_id: await getWorkflowIdFromLibraryId(eachSubject.rglb)
     });
   }
   return objectArray;
@@ -65,12 +85,12 @@ function StatusPairing(props) {
           "/pairing/by_libraries/",
           APIConfig
         );
-
+        
         let metadataList = [];
 
         // Grab a metadata list to be shown in the table if any
         if (pairingResponse.length > 0) {
-          metadataList = createMetadataObjectFromTNPairing(pairingResponse[0]);
+          metadataList = await createMetadataObjectFromTNPairing(pairingResponse[0]);
         }
 
         // Set some state

--- a/src/components/status/StatusRow.js
+++ b/src/components/status/StatusRow.js
@@ -33,6 +33,7 @@ const StyledTableRow = styled(TableRow)(({ theme }) => ({
 
 function groupWorkflow(metadataCompletedWorkflow, workflow_list) {
   const groupedWorkflow = {};
+  
   // Set Not Found by default
   for (const workflow of workflow_list) {
     groupedWorkflow[workflow] = "-";
@@ -58,19 +59,26 @@ function StatusRow(props) {
     const fetchData = async () => {
       try {
         if (!metadata.completed_workflows) {
-          const APIConfig = {
-            queryStringParameters: {
-              library_id: metadata.library_id,
-            },
-          };
 
+          // Construct workflow query param string
+          let queryPath = "/workflows?"
+          
+          for (const workflow_id of metadata.workflow_id){
+            queryPath = queryPath.concat("id=", workflow_id, "&")
+          }
+          
+          if (queryPath.slice(-1) === '&' ){
+            queryPath = queryPath.slice(0,-1)
+          }
+          
           const responseWorkflow = await API.get(
             "DataPortalApi",
-            "/workflows/",
-            APIConfig
+            queryPath
           );
+
           metadata["completed_workflows"] = responseWorkflow.results;
         }
+
         const groupedWorkflow = groupWorkflow(
           metadata["completed_workflows"],
           workflow_list
@@ -83,7 +91,10 @@ function StatusRow(props) {
           isOpen: true,
           dialogTitle: "Error",
           dialogContent:
-            "Sorry, An error has occured when fetching metadata. Please try again!",
+            ''.concat(
+            "Sorry, An error has occured when fetching metadata. Please try again!\n",
+            "\nError:", err
+            )
         });
       }
     };


### PR DESCRIPTION
- Use workflow_id at the `/libraryrun/` api to link statuses instead of library id (#15 )