### PR TITLE
Fix codepipeline buildspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ Prerequisite:
 The app will need to fetch data from the [data-portal-api](https://github.com/umccr/data-portal-apis). Before running this app, make sure to run the portal-api locally at `localhost:8000` (If it is run on a different port, you can change REACT_APP_DATA_PORTAL_API_DOMAIN variable at get_env.sh)  
 
 
-1. Install React dependancy  
+1. Check Node version, as our project need run with version >= 18
+        `node -v`
+2. Install React dependancy  
         `npm i`
-2. Fetch ENV variables from AWS Systems Manager Parameter Store. (This will store environment variable needed to the terminal)  
+3. Fetch ENV variables from AWS Systems Manager Parameter Store. (This will store environment variable needed to the terminal)  
         `source get_env.sh`
-3. Start the project and will be running at *http://localhost:3000/*  
+4. Start the project and will be running at *http://localhost:3000/*  
         `npm start`
 
 ### AWS-CDK Infrastructure

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
     runtime-versions:
       nodejs: 12
     commands:
-      - npm i react-scripts
+      - npm i --dev
   build:
     commands:
       - set -eu

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,9 +2,9 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: 18
     commands:
-      - npm i --dev
+      - npm i
   build:
     commands:
       - set -eu


### PR DESCRIPTION
It seems that the install should rely on the `package.json` instead

Should fix: https://umccr.slack.com/archives/C7QC9N8G4/p1710297760963109
Related: #86 