### PR TITLE
upgrade the codebuild image version to fit the nodejs 18

### DIFF
--- a/deploy/stacks/pipeline_stack.py
+++ b/deploy/stacks/pipeline_stack.py
@@ -135,7 +135,7 @@ class CdkPipelineStack(cdk.Stack):
             description="The project from codebuild to build react project.",
             project_name="DataPortalStatusPageReactBuild",
             environment=codebuild.BuildEnvironment(
-                build_image=codebuild.LinuxBuildImage.STANDARD_5_0
+                build_image=codebuild.LinuxBuildImage.STANDARD_7_0
             )
         )
 


### PR DESCRIPTION
As node version required, we need upgrade our LinuxBuildImage to 7.0, reference [here](https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html).
<img width="734" alt="image" src="https://github.com/umccr/data-portal-status-page/assets/160200168/e570bb9d-067d-4a51-b7e8-af4427200074">
