### PR TITLE
Change of code build image to fit our node upgrade

### DIFF
--- a/deploy/stacks/pipeline_stack.py
+++ b/deploy/stacks/pipeline_stack.py
@@ -135,7 +135,7 @@ class CdkPipelineStack(cdk.Stack):
             description="The project from codebuild to build react project.",
             project_name="DataPortalStatusPageReactBuild",
             environment=codebuild.BuildEnvironment(
-                build_image=codebuild.LinuxBuildImage.STANDARD_7_0
+                build_image=codebuild.LinuxBuildImage.from_code_build_image_id("aws/codebuild/standard:7.0"),
             )
         )
 


### PR DESCRIPTION
1. Major version updates (e.g., from 1.x to 2.x) may introduce breaking changes that require modifications to your code, but minor and patch updates within a major version typically do not.
2. For this concern,  we may need more talk to decide if we need upgrade our cdk from 1.x to 2.x. But we can also use static function to choose latest available image -- "aws/codebuild/standard:7.0"